### PR TITLE
Extendend Header serialization from 10 to 16 bits

### DIFF
--- a/model/lte-rrc-header.cc
+++ b/model/lte-rrc-header.cc
@@ -322,7 +322,7 @@ RrcAsn1Header::SerializePhysicalConfigDedicated (LteRrcSap::PhysicalConfigDedica
           SerializeBoolean (false);
 
           // Serialize srs-ConfigIndex
-          SerializeInteger (physicalConfigDedicated.soundingRsUlConfigDedicated.srsConfigIndex,0,1023);
+          SerializeInteger (physicalConfigDedicated.soundingRsUlConfigDedicated.srsConfigIndex,0,65535);
 
           // Serialize transmissionComb
           SerializeInteger (0,0,1);
@@ -2192,7 +2192,7 @@ RrcAsn1Header::DeserializePhysicalConfigDedicated (LteRrcSap::PhysicalConfigDedi
           bIterator = DeserializeBoolean (&duration,bIterator);
 
           // Deserialize srs-ConfigIndex
-          bIterator = DeserializeInteger (&slct,0,1023,bIterator);
+          bIterator = DeserializeInteger (&slct,0,65535,bIterator);
           physicalConfigDedicated->soundingRsUlConfigDedicated.srsConfigIndex = slct;
 
           // Deserialize transmissionComb


### PR DESCRIPTION
(De)SerializePhysicalConfigDedicated is now able to handle all 16 bits, giving the possibility to use SRS Periodicity up to 65.535 (in theory, actually 40.960 is the max currently implemented.
Tested.